### PR TITLE
Typeerror for credential var

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function setup(webContents) {
     // Retrieve saved senderId
     const savedSenderId = config.get('senderId');
     if (started) {
-      webContents.send(NOTIFICATION_SERVICE_STARTED, (credentials.fcm || {}).token);
+      webContents.send(NOTIFICATION_SERVICE_STARTED, ((credentials && credentials.fcm) || {}).token);
       return;
     }
     started = true;


### PR DESCRIPTION
Issue:
1) Access to fcm property from credential which is null.

In my organization we are using 'electron-fcm-push-receiver' for electron app, but we have very strict restrictions on self signed certificate due to which registration of fcm to google server keeps failing with certificate error.

When it fails we get many errors logged due to access "credentials.fcm" from the below screen shot.  This log keeps increasing at  our log management site.

![image](https://user-images.githubusercontent.com/797999/138216345-bc7c64b7-2727-4aa5-9b64-e6353ae78357.png)


![image](https://user-images.githubusercontent.com/797999/138215976-61e7587b-ac9d-4326-9259-e1571f9131c5.png)
